### PR TITLE
Fix mis-specified option and directory check

### DIFF
--- a/.functions/jump
+++ b/.functions/jump
@@ -43,7 +43,7 @@ function jump {
     "${SUDO_BINARY}" --prompt="[⚠️ ] Password required to run tlmgr: " -v
     echo "[📝] Updating LaTeX..."
     "${SUDO_BINARY}" "${TLMGR_BINARY}" update --self
-    "${SUDO_BINARY}" "${TLMGR_BINARY}" update –all
+    "${SUDO_BINARY}" "${TLMGR_BINARY}" update --all
   fi
 
 

--- a/bin/sublime_backup
+++ b/bin/sublime_backup
@@ -30,7 +30,7 @@ file_names=("Bash.sublime-settings" "Jekyll.sublime-settings" "Markdown.sublime-
 
 # TODO: Copy all files with the extension ".sublime-settings"
 
-if [[ -d "$HOME/Library/Application Support/Sublime Text 3/Packages/User" ]]; then
+if [[ ! -d "$HOME/Library/Application Support/Sublime Text 3/Packages/User" ]]; then
   echo "[❌] Sublime Text not installed"
   exit 1
 fi


### PR DESCRIPTION
## Summary
- correct LaTeX update flag in `jump`
- properly detect missing Sublime Text install before running backup

------
https://chatgpt.com/codex/tasks/task_e_6867192fac4883288db93da607749899