### PR TITLE
Search subdirectories for scripts

### DIFF
--- a/test
+++ b/test
@@ -30,14 +30,15 @@ function check_shellcheck {
 
 function find_files {
   # find_files
-  #   Find all regular files in source directory
+  #   Find all regular files in source directory and subdirectories
+  #   such as bin/ so nested shell scripts are linted
   
   while IFS=$'\n' read -r file; do 
     FILES+=("${file}"); 
-  done < <(/usr/bin/find . -maxdepth 1 -type f \
-            -not -iwholename '*.git*'   \
-            -not -iwholename '*venv*'   \
-            -not -iwholename '*.tar.xz' \
+  done < <(/usr/bin/find . -type f \
+            -not -path '*/.git/*' \
+            -not -path '*/venv/*' \
+            -not -name '*.tar.xz' \
             | /usr/bin/sort -u)
 }
 


### PR DESCRIPTION
## Summary
- update test script to search recursively so scripts inside subfolders (e.g. `bin/`) are linted

------
https://chatgpt.com/codex/tasks/task_e_68671a654f688328940f5d21f6a98ea0